### PR TITLE
Feature/week4 concurrency base

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -4,8 +4,11 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.retry.annotation.EnableRetry;
+
 import java.util.TimeZone;
 
+@EnableRetry
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class CommerceApiApplication {

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -51,7 +51,7 @@ public class OrderFacade {
         orderItems.forEach(order::addOrderItem);
 
         // 3. 쿠폰 적용 로직
-        applyCoupon(order, user, command.couponId());
+        applyCoupon(order, command.couponId());
 
         // 4. 최종 가격으로 포인트 차감
         BigDecimal finalPrice = order.getFinalPrice();
@@ -80,15 +80,15 @@ public class OrderFacade {
                 .toList();
     }
 
-    private void applyCoupon(OrderEntity order, UserEntity user, Long couponId) {
+    private void applyCoupon(OrderEntity order, Long couponId) {
         if (couponId == null) {
             return;
         }
 
         CouponEntity coupon = couponService.findById(couponId);
-        coupon.validateAvailability(user.getId());
+        coupon.validateAvailability(order.getUser().getId());
 
-        BigDecimal originalPrice = order.getTotalPrice();
+        BigDecimal originalPrice = order.getOriginalPrice();
         BigDecimal discountAmount = coupon.getDiscountAmount(originalPrice);
 
         coupon.use();

--- a/apps/commerce-api/src/main/java/com/loopers/domain/CustomCrudRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/CustomCrudRepository.java
@@ -3,7 +3,9 @@ package com.loopers.domain;
 import java.util.List;
 import java.util.Optional;
 
-public interface CustomCrudRepository<T> {
+public interface CustomCrudRepository<T extends BaseEntity> {
+
+    long count();
 
     T save(T entity);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandEntity.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.brand;
 
 import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class BrandEntity extends BaseEntity {
 
+    @Column(name = "brand_name", nullable = false, length = 50)
     private String brandName;
 
     public static BrandEntity create(String brandName) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.CustomCrudRepository;
+
+public interface BrandRepository extends CustomCrudRepository<BrandEntity> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
@@ -1,0 +1,103 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.user.UserEntity;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Getter
+public class CouponEntity {
+    private String name;
+    private UserEntity owner;
+    private DiscountPolicy discountPolicy;
+    private boolean isUsed = false;
+
+    private CouponEntity(String name, UserEntity owner, DiscountPolicy discountPolicy) {
+        Validator.validateName(name);
+        Validator.validateOwner(owner);
+        Validator.validateDiscountPolicy(discountPolicy);
+        this.name = name;
+        this.owner = owner;
+        this.discountPolicy = discountPolicy;
+    }
+
+    public static CouponEntity ofFixed(String name, UserEntity owner, long value) {
+        return new CouponEntity(name, owner, DiscountPolicy.ofFixed(value));
+    }
+
+    public static CouponEntity ofPercentage(String name, UserEntity owner, long rate) {
+        return new CouponEntity(name, owner, DiscountPolicy.ofPercentage(rate));
+    }
+
+    public BigDecimal getDiscountAmount(BigDecimal originalPrice) {
+        return discountPolicy.getDiscountAmount(originalPrice);
+    }
+
+    public void use() {
+        if (isUsed) {
+            throw new IllegalStateException("이미 사용된 쿠폰입니다.");
+        }
+        isUsed = true;
+    }
+
+    static class Validator {
+        static void validateName(String name) {
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException("쿠폰 이름은 필수입니다.");
+            }
+        }
+
+        static void validateOwner(UserEntity owner) {
+            if (owner == null) {
+                throw new IllegalArgumentException("쿠폰 소유자는 필수입니다.");
+            }
+        }
+
+        static void validateDiscountPolicy(DiscountPolicy discountPolicy) {
+            if (discountPolicy == null) {
+                throw new IllegalArgumentException("쿠폰 할인 정책은 필수입니다.");
+            }
+        }
+    }
+
+    static class DiscountPolicy {
+        private final CouponType type;
+        private final long value;
+
+        private DiscountPolicy(CouponType type, long value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        private static DiscountPolicy ofFixed(long amount) {
+            if (amount <= 0) {
+                throw new IllegalArgumentException("정액 쿠폰의 할인 금액은 0보다 커야 합니다.");
+            }
+            return new DiscountPolicy(CouponType.FIXED, amount);
+        }
+
+        private static DiscountPolicy ofPercentage(long rate) {
+            if (rate <= 0 || rate > 100) {
+                throw new IllegalArgumentException("정률 쿠폰의 할인 비율은 0% 초과 100% 이하여야 합니다.");
+            }
+            return new DiscountPolicy(CouponType.PERCENTAGE, rate);
+        }
+
+        public BigDecimal getDiscountAmount(BigDecimal originalPrice) {
+            if (type == CouponType.FIXED) {
+                return originalPrice.min(BigDecimal.valueOf(value));
+            }
+
+            if (type == CouponType.PERCENTAGE) {
+                BigDecimal rate = BigDecimal.valueOf(value);
+                BigDecimal hundred = new BigDecimal("100");
+
+                return originalPrice.multiply(rate)
+                        .divide(hundred, 0, RoundingMode.HALF_UP);
+            }
+
+            return BigDecimal.ZERO;
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
@@ -31,6 +31,9 @@ public class CouponEntity extends BaseEntity {
     @Embedded
     private DiscountPolicy discountPolicy;
 
+    @Version
+    long version;
+
     private CouponEntity(String name, UserEntity owner, DiscountPolicy discountPolicy) {
         Validator.validateName(name);
         Validator.validateOwner(owner);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
@@ -32,7 +32,7 @@ public class CouponEntity extends BaseEntity {
     private DiscountPolicy discountPolicy;
 
     @Version
-    long version;
+    private long version;
 
     private CouponEntity(String name, UserEntity owner, DiscountPolicy discountPolicy) {
         Validator.validateName(name);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.coupon;
 
+import com.loopers.domain.BaseEntity;
 import com.loopers.domain.user.UserEntity;
 import lombok.Getter;
 
@@ -7,7 +8,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 @Getter
-public class CouponEntity {
+public class CouponEntity extends BaseEntity {
     private String name;
     private UserEntity owner;
     private DiscountPolicy discountPolicy;
@@ -39,6 +40,15 @@ public class CouponEntity {
             throw new IllegalStateException("이미 사용된 쿠폰입니다.");
         }
         isUsed = true;
+    }
+
+    public void validateAvailability(Long userId) {
+        if (isUsed) {
+            throw new IllegalStateException("이미 사용된 쿠폰입니다.");
+        }
+        if (!owner.getId().equals(userId)) {
+            throw new IllegalArgumentException("쿠폰 소유자와 요청한 사용자의 ID가 일치하지 않습니다.");
+        }
     }
 
     static class Validator {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.CustomCrudRepository;
+
+public interface CouponRepository extends CustomCrudRepository<CouponEntity> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,9 +1,9 @@
 package com.loopers.domain.coupon;
 
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
 @RequiredArgsConstructor
 public class CouponService {
 
@@ -15,6 +15,6 @@ public class CouponService {
 
     public CouponEntity findById(Long id) {
         return couponRepository.findById(id)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "Coupon not found with id: " + id));
+                .orElseThrow(() -> new IllegalArgumentException("Coupon not found with id: " + id));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public CouponEntity save(CouponEntity entity) {
+        return couponRepository.save(entity);
+    }
+
+    public CouponEntity findById(Long id) {
+        return couponRepository.findById(id)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "Coupon not found with id: " + id));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.coupon;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,6 @@ public class CouponService {
 
     public CouponEntity findById(Long id) {
         return couponRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Coupon not found with id: " + id));
+                .orElseThrow(() -> new EntityNotFoundException("Coupon not found with id: " + id));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponType.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.coupon;
+
+public enum CouponType {
+    FIXED,
+    PERCENTAGE;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeCountDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeCountDto.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.like;
+
+public record LikeCountDto(
+        Long productId,
+        long count) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeEntity.java
@@ -3,11 +3,21 @@ package com.loopers.domain.like;
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.product.ProductEntity;
 import com.loopers.domain.user.UserEntity;
+import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Table(name = "likes")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 public class LikeEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
     private ProductEntity product;
 
     private LikeEntity(UserEntity user, ProductEntity product) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeEntity.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Entity
 @Table(name = "likes")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
@@ -34,5 +36,19 @@ public class LikeEntity extends BaseEntity {
 
     public static LikeEntity create(UserEntity user, ProductEntity product) {
         return new LikeEntity(user, product);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LikeEntity that)) return false;
+
+        if (!user.getId().equals(that.user.getId())) return false;
+        return product.getId().equals(that.product.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user.getId(), product.getId());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -3,17 +3,14 @@ package com.loopers.domain.like;
 import com.loopers.domain.CustomCrudRepository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 public interface LikeRepository extends CustomCrudRepository<LikeEntity> {
 
-    long countAll();
-
     long countByProductId(Long productId);
 
-    Map<Long, Long> countByProductIds(List<Long> productIds);
+    List<LikeCountDto> findLikeCountsByProductIds(List<Long> productIds);
 
     Optional<LikeEntity> findByUserIdAndProductId(Long userId, Long productId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -17,4 +17,6 @@ public interface LikeRepository extends CustomCrudRepository<LikeEntity> {
     void deleteByUserIdAndProductId(Long userId, Long productId);
 
     Set<Long> findLikedProductIdsByUserIdAndProductIds(Long userId, List<Long> productIds);
+
+    LikeEntity saveOrFind(LikeEntity likeEntity);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -17,19 +17,14 @@ public class LikeService {
     private final ProductRepository productRepository;
 
     public LikeEntity addLike(long userId, long productId) {
-        return likeRepository.findByUserIdAndProductId(userId, productId)
-                .orElseGet(() -> {
-                    UserEntity user = userRepository.findById(userId)
-                            .orElseThrow(() -> new IllegalArgumentException(
-                                    "사용자를 찾을 수 없습니다. userId: " + userId
-                            ));
-                    ProductEntity product = productRepository.findById(productId)
-                            .orElseThrow(() -> new IllegalArgumentException(
-                                    "상품을 찾을 수 없습니다. productId: " + productId
-                            ));
-                    LikeEntity newLike = LikeEntity.create(user, product);
-                    return likeRepository.save(newLike);
-                });
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId: " + userId));
+        ProductEntity product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다. productId: " + productId));
+
+        LikeEntity newLike = LikeEntity.create(user, product);
+
+        return likeRepository.saveOrFind(newLike);
     }
 
     public void removeLike(long userId, long productId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -4,11 +4,10 @@ import com.loopers.domain.product.ProductEntity;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserRepository;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class LikeService {
@@ -21,13 +20,11 @@ public class LikeService {
         return likeRepository.findByUserIdAndProductId(userId, productId)
                 .orElseGet(() -> {
                     UserEntity user = userRepository.findById(userId)
-                            .orElseThrow(() -> new CoreException(
-                                    ErrorType.BAD_REQUEST,
+                            .orElseThrow(() -> new IllegalArgumentException(
                                     "사용자를 찾을 수 없습니다. userId: " + userId
                             ));
                     ProductEntity product = productRepository.findById(productId)
-                            .orElseThrow(() -> new CoreException(
-                                    ErrorType.BAD_REQUEST,
+                            .orElseThrow(() -> new IllegalArgumentException(
                                     "상품을 찾을 수 없습니다. productId: " + productId
                             ));
                     LikeEntity newLike = LikeEntity.create(user, product);
@@ -64,7 +61,9 @@ public class LikeService {
         if (productIds == null || productIds.isEmpty()) {
             return Collections.emptyMap();
         }
-        return likeRepository.countByProductIds(productIds);
+        return likeRepository.findLikeCountsByProductIds(productIds)
+                .stream()
+                .collect(Collectors.toMap(LikeCountDto::productId, LikeCountDto::count));
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -6,11 +6,23 @@ public class OrderCommand {
 
     public record Place(
             Long userId,
-            List<OrderItemDetail> items
+            List<OrderItemDetail> items,
+            Long couponId
     ) {
         public Place {
             Validator.validateUserId(userId);
             Validator.validateItems(items);
+        }
+
+        public static Place withoutCoupon(Long userId, List<OrderItemDetail> items) {
+            return new Place(userId, items, null);
+        }
+
+        public static Place withCoupon(Long userId, List<OrderItemDetail> items, Long couponId) {
+            if (couponId == null || couponId <= 0) {
+                throw new IllegalArgumentException("쿠폰 ID는 유효해야 합니다.");
+            }
+            return new Place(userId, items, couponId);
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
@@ -3,20 +3,34 @@ package com.loopers.domain.order;
 import com.loopers.application.order.OrderItemInfo;
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.user.UserEntity;
+import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+@Entity
+@Table(name = "orders")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 public class OrderEntity extends BaseEntity {
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("id ASC")
     private List<OrderItem> items = new ArrayList<>();
+    @Column(name = "total_price", precision = 10, nullable = false)
     private BigDecimal totalPrice = BigDecimal.ZERO;
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private OrderStatus status = OrderStatus.PENDING;
+    @Column(name = "applied_coupon_id")
     private Long appliedCouponId = null;
+    @Column(name = "discount_amount", precision = 10, nullable = false)
     private BigDecimal discountAmount = BigDecimal.ZERO;
 
     private OrderEntity(UserEntity user) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
@@ -53,6 +53,7 @@ public class OrderEntity extends BaseEntity {
         OrderItem newItem = OrderItem.create(this, item.productId(), item.productName(), item.price(), item.quantity());
         items.add(newItem);
         originalPrice = originalPrice.add(newItem.getTotalPrice());
+        finalPrice = originalPrice;
     }
 
     public List<Long> getProductIds() {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
@@ -16,6 +16,8 @@ public class OrderEntity extends BaseEntity {
     private List<OrderItem> items = new ArrayList<>();
     private BigDecimal totalPrice = BigDecimal.ZERO;
     private OrderStatus status = OrderStatus.PENDING;
+    private Long appliedCouponId = null;
+    private BigDecimal discountAmount = BigDecimal.ZERO;
 
     private OrderEntity(UserEntity user) {
         this.user = user;
@@ -68,6 +70,15 @@ public class OrderEntity extends BaseEntity {
             throw new IllegalStateException("오직 대기 중인 주문만 실패처리할 수 있습니다.");
         }
         status = OrderStatus.FAILED;
+    }
+
+    public void applyDiscount(Long couponId, BigDecimal amount) {
+        this.appliedCouponId = couponId;
+        this.discountAmount = amount;
+    }
+
+    public BigDecimal getFinalPrice() {
+        return getTotalPrice().subtract(this.discountAmount);
     }
 
     enum OrderStatus {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
@@ -19,7 +19,7 @@ public class OrderInfo {
                 orderEntity.getId(),
                 orderEntity.getUser().getId(),
                 orderEntity.getStatus().name(),
-                orderEntity.getTotalPrice()
+                orderEntity.getOriginalPrice()
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -1,17 +1,28 @@
 package com.loopers.domain.order;
 
 import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
+@Entity
+@Table(name = "order_items")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 public class OrderItem extends BaseEntity {
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
     private OrderEntity order;
+    @Column(name = "product_id", nullable = false)
     private Long productId;
+    @Column(name = "product_name", nullable = false, length = 100)
     private String productName;
+    @Column(name = "price", precision = 10, nullable = false)
     private BigDecimal price;
+    @Column(name = "quantity", nullable = false)
     private int quantity;
 
     private OrderItem(OrderEntity order, Long productId, String productName, BigDecimal price, int quantity) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,6 +1,8 @@
 package com.loopers.domain.order;
 
 import com.loopers.domain.CustomCrudRepository;
+import com.loopers.domain.user.UserEntity;
 
 public interface OrderRepository extends CustomCrudRepository<OrderEntity> {
+    long countByUser(UserEntity user);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -3,5 +3,4 @@ package com.loopers.domain.order;
 import com.loopers.domain.CustomCrudRepository;
 
 public interface OrderRepository extends CustomCrudRepository<OrderEntity> {
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,7 +1,9 @@
 package com.loopers.domain.order;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
 @RequiredArgsConstructor
 public class OrderService {
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface PointRepository extends CustomCrudRepository<PointEntity> {
     Optional<PointEntity> findByUserId(Long id);
+
+    Optional<PointEntity> findByUserIdWithPessimisticLock(long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -9,4 +9,6 @@ public interface PointService {
     PointEntity findByUserId(Long id);
 
     void deductPoints(Long id, BigDecimal totalPrice);
+
+    PointEntity findByUserIdWithPessimisticLock(long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
@@ -16,13 +16,15 @@ public class ProductEntity extends BaseEntity {
 
     @Column(nullable = false, name = "name", length = 50)
     private String name;
-    @Column(nullable = false, name = "price", precision = 10, scale = 0)
+    @Column(nullable = false, name = "price", precision = 10)
     private BigDecimal price;
     @Column(nullable = false, name = "stock")
     private int stock;
     @ManyToOne
     @JoinColumn(name = "brand_id", nullable = false)
     private BrandEntity brand;
+    @Version
+    long version;
 
     private ProductEntity(String productName, int price, int initialStock, BrandEntity brand) {
         if (productName == null || productName.isBlank() || price <= 0 || initialStock < 0 || brand == null) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,13 +1,14 @@
 package com.loopers.domain.product;
 
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 @RequiredArgsConstructor
 public class ProductService {
 
@@ -18,7 +19,7 @@ public class ProductService {
             throw new IllegalArgumentException("상품 ID는 null일 수 없습니다");
         }
         return productRepository.findById(id)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 ID의 상품을 찾을 수 없습니다: " + id));
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 상품을 찾을 수 없습니다: " + id));
     }
 
     public Page<ProductEntity> findAll(Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserServiceImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserServiceImpl.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.user;
 
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -15,19 +14,19 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserEntity save(UserCommand.Create userCreateCommand) {
         if (userCreateCommand == null) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "User creation command cannot be null.");
+            throw new IllegalArgumentException("User creation command cannot be null.");
         }
 
         try {
             return userRepository.save(userCreateCommand.toEntity());
         } catch (DataIntegrityViolationException e) {
-            throw new CoreException(ErrorType.CONFLICT, e.getMessage());
+            throw new IllegalArgumentException(e.getMessage());
         }
     }
 
     @Override
     public UserEntity findById(Long id) {
         return userRepository.findById(id)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "User not found with id: " + id));
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/AbstractRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/AbstractRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.loopers.infrastructure;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.CustomCrudRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public abstract class AbstractRepositoryImpl<T extends BaseEntity, R extends JpaRepository<T, Long>> implements CustomCrudRepository<T> {
+    protected final R jpaRepository;
+
+    @Override
+    public long count() {
+        return jpaRepository.count();
+    }
+
+    @Override
+    public T save(T entity) {
+        return jpaRepository.save(entity);
+    }
+
+    @Override
+    public Optional<T> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<T> findAllById(List<Long> ids) {
+        return jpaRepository.findAllById(ids);
+    }
+
+    @Override
+    public List<T> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaRepository.findById(id)
+                .ifPresent(entity -> {
+                    entity.delete();
+                    save(entity);
+                });
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.BrandEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BrandJpaRepository extends JpaRepository<BrandEntity, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.BrandEntity;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.infrastructure.AbstractRepositoryImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BrandRepositoryImpl extends AbstractRepositoryImpl<BrandEntity, BrandJpaRepository> implements BrandRepository {
+    public BrandRepositoryImpl(BrandJpaRepository jpaRepository) {
+        super(jpaRepository);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<CouponEntity, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponEntity;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.infrastructure.AbstractRepositoryImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CouponRepositoryImpl extends AbstractRepositoryImpl<CouponEntity, CouponJpaRepository> implements CouponRepository {
+    public CouponRepositoryImpl(CouponJpaRepository jpaRepository) {
+        super(jpaRepository);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,0 +1,30 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.LikeCountDto;
+import com.loopers.domain.like.LikeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface LikeJpaRepository extends JpaRepository<LikeEntity, Long> {
+    long countByProductId(Long productId);
+
+    @Query("SELECT new com.loopers.domain.like.LikeCountDto(l.product.id, COUNT(l.id)) " +
+            "FROM LikeEntity l " +
+            "WHERE l.product.id IN :productIds AND l.deletedAt IS NULL " +
+            "GROUP BY l.product.id")
+    List<LikeCountDto> findLikeCountsByProductIds(@Param("productIds") List<Long> productIds);
+
+    Optional<LikeEntity> findByUserIdAndProductId(Long userId, Long productId);
+
+    @Query("SELECT l.product.id " +
+            "FROM LikeEntity l " +
+            "WHERE l.user.id = :userId " +
+            "AND l.product.id IN :productIds " +
+            "AND l.deletedAt IS NULL")
+    Set<Long> findLikedProductIdsByUserIdAndProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.loopers.domain.like.LikeCountDto;
 import com.loopers.domain.like.LikeEntity;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.infrastructure.AbstractRepositoryImpl;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -40,5 +41,16 @@ public class LikeRepositoryImpl extends AbstractRepositoryImpl<LikeEntity, LikeJ
     @Override
     public Set<Long> findLikedProductIdsByUserIdAndProductIds(Long userId, List<Long> productIds) {
         return jpaRepository.findLikedProductIdsByUserIdAndProductIds(userId, productIds);
+    }
+
+    @Override
+    public LikeEntity saveOrFind(LikeEntity likeEntity) {
+        try {
+            return jpaRepository.save(likeEntity);
+        } catch (DataIntegrityViolationException e) {
+            return jpaRepository
+                    .findByUserIdAndProductId(likeEntity.getUser().getId(), likeEntity.getProduct().getId())
+                    .orElseThrow(() -> new IllegalStateException("데이터 중복 예외 후 조회에 실패했습니다."));
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.LikeCountDto;
+import com.loopers.domain.like.LikeEntity;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.infrastructure.AbstractRepositoryImpl;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+public class LikeRepositoryImpl extends AbstractRepositoryImpl<LikeEntity, LikeJpaRepository> implements LikeRepository {
+    public LikeRepositoryImpl(LikeJpaRepository jpaRepository) {
+        super(jpaRepository);
+    }
+
+    @Override
+    public long countByProductId(Long productId) {
+        return jpaRepository.countByProductId(productId);
+    }
+
+    @Override
+    public List<LikeCountDto> findLikeCountsByProductIds(List<Long> productIds) {
+        return jpaRepository.findLikeCountsByProductIds(productIds);
+    }
+
+    @Override
+    public Optional<LikeEntity> findByUserIdAndProductId(Long userId, Long productId) {
+        return jpaRepository.findByUserIdAndProductId(userId, productId);
+    }
+
+    @Override
+    public void deleteByUserIdAndProductId(Long userId, Long productId) {
+        findByUserIdAndProductId(userId, productId)
+                .ifPresent(LikeEntity::delete);
+    }
+
+    @Override
+    public Set<Long> findLikedProductIdsByUserIdAndProductIds(Long userId, List<Long> productIds) {
+        return jpaRepository.findLikedProductIdsByUserIdAndProductIds(userId, productIds);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,7 +1,9 @@
 package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.OrderEntity;
+import com.loopers.domain.user.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderJpaRepository extends JpaRepository<OrderEntity, Long> {
+    long countByUser(UserEntity user);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.OrderEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderJpaRepository extends JpaRepository<OrderEntity, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.OrderEntity;
 import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.user.UserEntity;
 import com.loopers.infrastructure.AbstractRepositoryImpl;
 import org.springframework.stereotype.Component;
 
@@ -9,5 +10,10 @@ import org.springframework.stereotype.Component;
 public class OrderRepositoryImpl extends AbstractRepositoryImpl<OrderEntity, OrderJpaRepository> implements OrderRepository {
     public OrderRepositoryImpl(OrderJpaRepository jpaRepository) {
         super(jpaRepository);
+    }
+
+    @Override
+    public long countByUser(UserEntity user) {
+        return jpaRepository.countByUser(user);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.OrderEntity;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.infrastructure.AbstractRepositoryImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderRepositoryImpl extends AbstractRepositoryImpl<OrderEntity, OrderJpaRepository> implements OrderRepository {
+    public OrderRepositoryImpl(OrderJpaRepository jpaRepository) {
+        super(jpaRepository);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,10 +1,19 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.PointEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PointJpaRepository extends JpaRepository<PointEntity, Long> {
+
     Optional<PointEntity> findByUserId(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from PointEntity p where p.user.id = :userId")
+    Optional<PointEntity> findByUserIdWithPessimisticLock(@Param("userId") Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -2,48 +2,25 @@ package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.PointEntity;
 import com.loopers.domain.point.PointRepository;
-import lombok.RequiredArgsConstructor;
+import com.loopers.infrastructure.AbstractRepositoryImpl;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Optional;
 
 @Component
-@RequiredArgsConstructor
-public class PointRepositoryImpl implements PointRepository {
-    private final PointJpaRepository pointJpaRepository;
+public class PointRepositoryImpl extends AbstractRepositoryImpl<PointEntity, PointJpaRepository> implements PointRepository {
 
-    @Override
-    public PointEntity save(PointEntity point) {
-        return pointJpaRepository.save(point);
-    }
-
-    @Override
-    public Optional<PointEntity> findById(Long id) {
-        return pointJpaRepository.findById(id);
-    }
-
-    @Override
-    public List<PointEntity> findAllById(List<Long> ids) {
-        return pointJpaRepository.findAllById(ids);
-    }
-
-    @Override
-    public List<PointEntity> findAll() {
-        return pointJpaRepository.findAll();
-    }
-
-    @Override
-    public void deleteById(Long id) {
-        pointJpaRepository.findById(id)
-                .ifPresent(point -> {
-                    point.delete();
-                    save(point);
-                });
+    public PointRepositoryImpl(PointJpaRepository jpaRepository) {
+        super(jpaRepository);
     }
 
     @Override
     public Optional<PointEntity> findByUserId(Long id) {
-        return pointJpaRepository.findByUserId(id);
+        return jpaRepository.findByUserId(id);
+    }
+
+    @Override
+    public Optional<PointEntity> findByUserIdWithPessimisticLock(long userId) {
+        return jpaRepository.findByUserIdWithPessimisticLock(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.infrastructure.AbstractRepositoryImpl;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductRepositoryImpl extends AbstractRepositoryImpl<ProductEntity, ProductJpaRepository> implements ProductRepository {
+    public ProductRepositoryImpl(ProductJpaRepository jpaRepository) {
+        super(jpaRepository);
+    }
+
+    @Override
+    public Page<ProductEntity> findAll(Pageable pageable) {
+        return jpaRepository.findAll(pageable);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -2,43 +2,12 @@ package com.loopers.infrastructure.user;
 
 import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserRepository;
-import lombok.RequiredArgsConstructor;
+import com.loopers.infrastructure.AbstractRepositoryImpl;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Optional;
-
 @Component
-@RequiredArgsConstructor
-public class UserRepositoryImpl implements UserRepository {
-    private final UserJpaRepository userJpaRepository;
-
-    @Override
-    public UserEntity save(UserEntity userEntity) {
-        return userJpaRepository.save(userEntity);
-    }
-
-    @Override
-    public Optional<UserEntity> findById(Long id) {
-        return userJpaRepository.findById(id);
-    }
-
-    @Override
-    public List<UserEntity> findAllById(List<Long> ids) {
-        return userJpaRepository.findAllById(ids);
-    }
-
-    @Override
-    public List<UserEntity> findAll() {
-        return userJpaRepository.findAll();
-    }
-
-    @Override
-    public void deleteById(Long id) {
-        userJpaRepository.findById(id)
-                .ifPresent(user -> {
-                    user.delete();
-                    save(user);
-                });
+public class UserRepositoryImpl extends AbstractRepositoryImpl<UserEntity, UserJpaRepository> implements UserRepository {
+    public UserRepositoryImpl(UserJpaRepository jpaRepository) {
+        super(jpaRepository);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -132,6 +133,11 @@ public class ApiControllerAdvice {
         } else {
             return failureResponse(ErrorType.BAD_REQUEST, null);
         }
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleNotFound(EntityNotFoundException e) {
+        return failureResponse(ErrorType.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
@@ -2,6 +2,7 @@ package com.loopers.application.order;
 
 import com.loopers.domain.brand.BrandEntity;
 import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.coupon.CouponEntity;
 import com.loopers.domain.coupon.CouponRepository;
 import com.loopers.domain.order.OrderCommand;
 import com.loopers.domain.order.OrderRepository;
@@ -19,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -26,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 public class OrderFacadeConcurrencyTest {
@@ -75,23 +78,21 @@ public class OrderFacadeConcurrencyTest {
                 LocalDate.now().minusYears(20));
     }
 
-    @DisplayName("동시에 100개의 주문이 들어올 때, ")
+    @DisplayName("동시성 테스트")
     @Nested
     class PlaceOrderConcurrencyTest {
 
-        final int threadCount = 100;
-
-        @DisplayName("재고가 1개일 경우, 단 1개의 주문만 성공해야 한다.")
+        @DisplayName("재고가 1개인 상품을 100명이 동시에 주문하면, 1개의 주문만 성공해야 한다.")
         @Test
         void onlyOneOrderShouldSucceed_whenStockIsOne() throws InterruptedException {
             // arrange
-            // 사용자 생성
+            final int threadCount = 100;
             UserEntity savedUser = userRepository.save(testUser);
-            // 포인트 생성
+
             PointEntity point = pointRepository.save(new PointEntity(savedUser));
             point.charge(DEFAULT_POINT_AMOUNT);
             pointRepository.save(point);
-            // 상품 A는 재고가 1개
+
             BrandEntity brand = brandRepository.save(BrandEntity.create("나이키"));
             productA = productRepository.save(ProductEntity.create("ProductA", 100, 1, brand));
 
@@ -130,9 +131,161 @@ public class OrderFacadeConcurrencyTest {
             // assert
             ProductEntity finalProduct = productRepository.findById(productA.getId()).orElseThrow();
 
-            assertThat(successCount.get()).isEqualTo(1); // 단 1개의 주문만 성공했는지 확인
-            assertThat(failCount.get()).isEqualTo(threadCount - 1); // 나머지 주문은 모두 실패했는지 확인
-            assertThat(finalProduct.getStock()).isZero(); // 최종 재고가 0인지 확인
+            // 단 1개의 주문만 성공했는지 확인
+            assertThat(successCount.get()).isEqualTo(1);
+
+            // 나머지 주문은 모두 실패했는지 확인
+            assertThat(failCount.get()).isEqualTo(threadCount - 1);
+            
+            // 최종 재고가 0인지 확인
+            assertThat(finalProduct.getStock()).isZero();
+        }
+
+        @DisplayName("수량이 1개인 쿠폰을 동일한 사용자가 동시에 사용하면, 1개의 주문만 성공해야 한다.")
+        @Test
+        void onlyOneOrderShouldSucceed_whenUsingOneCouponConcurrently() throws InterruptedException {
+            // arrange
+            final int threadCount = 100;
+            UserEntity userA = userRepository.save(UserEntity.create("userA", "a@test.com", UserGender.M, LocalDate.now().minusYears(20)));
+
+            PointEntity pointA = pointRepository.save(new PointEntity(userA));
+            pointA.charge(DEFAULT_POINT_AMOUNT);
+            pointRepository.save(pointA);
+
+            BrandEntity brand = brandRepository.save(BrandEntity.create("나이키"));
+            ProductEntity product = productRepository.save(ProductEntity.create("Product A", 10000, 10, brand));
+            CouponEntity coupon = couponRepository.save(CouponEntity.ofFixed("한정수량 쿠폰", userA, 1000L));
+
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            // act
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        orderFacade.placeOrder(new OrderCommand.Place(userA.getId(), List.of(new OrderCommand.OrderItemDetail(product.getId(), 1)), coupon.getId()));
+                        successCount.getAndIncrement();
+                    } catch (Exception e) {
+                        failCount.getAndIncrement();
+                        System.out.println("Order failed: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            executorService.shutdown();
+
+            // assert
+            // 단 1개의 주문만 성공했는지 확인
+            assertThat(successCount.get()).isEqualTo(1);
+
+            // 나머지 주문은 모두 실패했는지 확인
+            assertThat(failCount.get()).isEqualTo(threadCount - 1);
+
+            // 쿠폰이 사용된 상태인지 확인
+            CouponEntity finalCoupon = couponRepository.findById(coupon.getId()).orElseThrow();
+            assertThat(finalCoupon.isUsed()).isTrue();
+
+            // 주문이 생성되었는지 확인
+            assertThat(orderRepository.count()).isEqualTo(1);
+        }
+
+        @DisplayName("포인트가 부족하면 주문이 실패하고, 사용했던 재고와 쿠폰은 모두 롤백되어야 한다.")
+        @Test
+        void stockAndCouponShouldBeRolledBack_whenPointIsInsufficient() {
+            // arrange
+            UserEntity user = userRepository.save(UserEntity.create("poorUser", "poor@test.com", UserGender.M, LocalDate.now().minusYears(20)));
+            PointEntity point = new PointEntity(user);
+            point.charge(BigDecimal.valueOf(100));
+            pointRepository.save(point);
+
+            BrandEntity brand = brandRepository.save(BrandEntity.create("샤넬"));
+            int initialStock = 10;
+            ProductEntity product = productRepository.save(ProductEntity.create("향수", 1000, initialStock, brand));
+
+            CouponEntity coupon = couponRepository.save(CouponEntity.ofFixed("민생지원쿠폰", user, 100L));
+
+            OrderCommand.Place command = new OrderCommand.Place(
+                    user.getId(),
+                    List.of(new OrderCommand.OrderItemDetail(product.getId(), 1)),
+                    coupon.getId()
+            );
+
+            // act & assert
+            assertThrows(IllegalStateException.class, () -> {
+                orderFacade.placeOrder(command);
+            });
+
+            // 상품 재고가 원상 복구되었는지 확인 (롤백)
+            ProductEntity productAfterOrder = productRepository.findById(product.getId()).orElseThrow();
+            assertThat(productAfterOrder.getStock()).isEqualTo(initialStock);
+
+            // 쿠폰이 '사용 안 됨' 상태로 롤백되었는지 확인
+            CouponEntity couponAfterOrder = couponRepository.findById(coupon.getId()).orElseThrow();
+            assertThat(couponAfterOrder.isUsed()).isFalse();
+
+            // 주문 자체가 생성되지 않았는지 확인
+            assertThat(orderRepository.count()).isZero();
+        }
+
+        @DisplayName("동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.")
+        @Test
+        void pointShouldBeDeductedCorrectly_whenSameUserOrdersConcurrently() throws InterruptedException {
+            final int threadCount = 5;
+
+            // arrange
+            UserEntity user = userRepository.save(UserEntity.create("user", "test@test.com", UserGender.F, LocalDate.now().minusYears(25)));
+            BigDecimal initialPoints = BigDecimal.valueOf(10000000);
+            PointEntity point = pointRepository.save(new PointEntity(user));
+            point.charge(initialPoints);
+            pointRepository.save(point);
+
+            BrandEntity brand = brandRepository.save(BrandEntity.create("madeInChina"));
+            List<ProductEntity> produtcs = new ArrayList<>();
+            List<OrderCommand.Place> commands = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                produtcs.add(productRepository.save(ProductEntity.create("상품" + (i + 1), 1000, 100, brand)));
+                commands.add(OrderCommand.Place.withoutCoupon(user.getId(), List.of(new OrderCommand.OrderItemDetail(produtcs.get(i).getId(), 1))));
+            }
+
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            AtomicInteger successCount = new AtomicInteger();
+
+            // act
+            for (int i = 0; i < threadCount; i++) {
+                int finalI = i;
+                executorService.submit(() -> {
+                    try {
+                        orderFacade.placeOrder(commands.get(finalI));
+                        successCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            executorService.shutdown();
+
+            // assert
+            // 주문 모두 성공했는지 확인
+            assertThat(successCount.get()).isEqualTo(threadCount);
+
+            // 포인트가 정확하게 차감되었는지 확인
+            PointEntity finalPoint = pointRepository.findById(point.getId()).orElseThrow();
+            BigDecimal expectedPoints = initialPoints
+                    .subtract(produtcs.stream().map(ProductEntity::getPrice).reduce(BigDecimal.ZERO, BigDecimal::add));
+            assertThat(finalPoint.getAmount()).isEqualByComparingTo(expectedPoints);
+
+            // 성공 횟수만큼 주문이 생성되었는지 확인
+            assertThat(orderRepository.countByUser(user)).isEqualTo(commands.size());
         }
     }
+
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
@@ -136,7 +136,7 @@ public class OrderFacadeConcurrencyTest {
 
             // 나머지 주문은 모두 실패했는지 확인
             assertThat(failCount.get()).isEqualTo(threadCount - 1);
-            
+
             // 최종 재고가 0인지 확인
             assertThat(finalProduct.getStock()).isZero();
         }
@@ -245,11 +245,11 @@ public class OrderFacadeConcurrencyTest {
             pointRepository.save(point);
 
             BrandEntity brand = brandRepository.save(BrandEntity.create("madeInChina"));
-            List<ProductEntity> produtcs = new ArrayList<>();
+            List<ProductEntity> products = new ArrayList<>();
             List<OrderCommand.Place> commands = new ArrayList<>();
             for (int i = 0; i < threadCount; i++) {
-                produtcs.add(productRepository.save(ProductEntity.create("상품" + (i + 1), 1000, 100, brand)));
-                commands.add(OrderCommand.Place.withoutCoupon(user.getId(), List.of(new OrderCommand.OrderItemDetail(produtcs.get(i).getId(), 1))));
+                products.add(productRepository.save(ProductEntity.create("상품" + (i + 1), 1000, 100, brand)));
+                commands.add(OrderCommand.Place.withoutCoupon(user.getId(), List.of(new OrderCommand.OrderItemDetail(products.get(i).getId(), 1))));
             }
 
             ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
@@ -279,7 +279,7 @@ public class OrderFacadeConcurrencyTest {
             // 포인트가 정확하게 차감되었는지 확인
             PointEntity finalPoint = pointRepository.findById(point.getId()).orElseThrow();
             BigDecimal expectedPoints = initialPoints
-                    .subtract(produtcs.stream().map(ProductEntity::getPrice).reduce(BigDecimal.ZERO, BigDecimal::add));
+                    .subtract(products.stream().map(ProductEntity::getPrice).reduce(BigDecimal.ZERO, BigDecimal::add));
             assertThat(finalPoint.getAmount()).isEqualByComparingTo(expectedPoints);
 
             // 성공 횟수만큼 주문이 생성되었는지 확인

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
@@ -1,0 +1,138 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.brand.BrandEntity;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.UserGender;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class OrderFacadeConcurrencyTest {
+
+    /*
+     * 주문 파사드 동시성 테스트
+     */
+
+    private static final BigDecimal DEFAULT_POINT_AMOUNT = BigDecimal.valueOf(1000000L);
+
+    private UserEntity testUser;
+    private ProductEntity productA;
+
+    @Autowired
+    private OrderFacade orderFacade;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private OrderRepository orderRepository;
+    @Autowired
+    private PointRepository pointRepository;
+    @Autowired
+    private CouponRepository couponRepository;
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @BeforeEach
+    public void setUp() {
+        setUpTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    private void setUpTestData() {
+        testUser = UserEntity.create(
+                "test",
+                "test@email.com",
+                UserGender.M,
+                LocalDate.now().minusYears(20));
+    }
+
+    @DisplayName("동시에 100개의 주문이 들어올 때, ")
+    @Nested
+    class PlaceOrderConcurrencyTest {
+
+        final int threadCount = 100;
+
+        @DisplayName("재고가 1개일 경우, 단 1개의 주문만 성공해야 한다.")
+        @Test
+        void onlyOneOrderShouldSucceed_whenStockIsOne() throws InterruptedException {
+            // arrange
+            // 사용자 생성
+            UserEntity savedUser = userRepository.save(testUser);
+            // 포인트 생성
+            PointEntity point = pointRepository.save(new PointEntity(savedUser));
+            point.charge(DEFAULT_POINT_AMOUNT);
+            pointRepository.save(point);
+            // 상품 A는 재고가 1개
+            BrandEntity brand = brandRepository.save(BrandEntity.create("나이키"));
+            productA = productRepository.save(ProductEntity.create("ProductA", 100, 1, brand));
+
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+
+            try (ExecutorService executorService = Executors.newFixedThreadPool(32)) {
+                CountDownLatch latch = new CountDownLatch(threadCount);
+
+                // act
+                for (int i = 0; i < threadCount; i++) {
+                    executorService.submit(() -> {
+                        try {
+                            OrderCommand.Place command = OrderCommand.Place.withoutCoupon(
+                                    savedUser.getId(),
+                                    List.of(new OrderCommand.OrderItemDetail(productA.getId(), 1))
+                            );
+                            orderFacade.placeOrder(command);
+                            successCount.getAndIncrement();
+                        } catch (IllegalArgumentException e) {
+                            if (e.getMessage().contains("재고가 부족합니다")) {
+                                failCount.getAndIncrement();
+                            }
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                }
+
+                latch.await();
+                executorService.shutdown();
+            }
+
+            // assert
+            ProductEntity finalProduct = productRepository.findById(productA.getId()).orElseThrow();
+
+            assertThat(successCount.get()).isEqualTo(1); // 단 1개의 주문만 성공했는지 확인
+            assertThat(failCount.get()).isEqualTo(threadCount - 1); // 나머지 주문은 모두 실패했는지 확인
+            assertThat(finalProduct.getStock()).isZero(); // 최종 재고가 0인지 확인
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
@@ -20,7 +20,7 @@ import com.loopers.infrastructure.order.FakeOrderRepository;
 import com.loopers.infrastructure.point.FakePointRepository;
 import com.loopers.infrastructure.product.FakeProductRepository;
 import com.loopers.infrastructure.user.FakeUserRepository;
-import com.loopers.support.error.CoreException;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -101,7 +101,7 @@ public class OrderFacadeTest {
             );
 
             // act & assert
-            assertThrows(CoreException.class, () -> orderFacade.placeOrder(command));
+            assertThrows(EntityNotFoundException.class, () -> orderFacade.placeOrder(command));
         }
 
         @DisplayName("주문 항목이 유효하지 않으면 예외가 발생한다")

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class OrderFacadeTest {
 
     /*
-     * 주문 서비스 테스트
+     * 주문 파사드 테스트
      *
      */
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponEntityTest.java
@@ -1,0 +1,177 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.UserGender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CouponEntityTest {
+
+    /*
+     * 쿠폰 엔티티 테스트
+     * - [o]  쿠폰 생성 시 이름, 종류, 소유자 정보가 있어야 한다.
+     * - [o]  쿠폰 종류는 정액 / 정률로 구분된다.
+     *   - [o]  정액 쿠폰의 할인 금액은 0보다 커야 한다.
+     *   - [o]  정률 쿠폰의 할인 비율은 0% 초과 100% 이하여야 한다.
+     * - [o]  쿠폰은 최대 한번만 사용될 수 있다.
+     */
+
+    private UserEntity owner;
+
+    @BeforeEach
+    void setUp() {
+        owner = UserEntity.create(
+                "testuser",
+                "test@test.com",
+                UserGender.M,
+                LocalDate.of(2000, 1, 1));
+    }
+
+    @DisplayName("쿠폰을 생성할 때, ")
+    @Nested
+    class CreateCoupon {
+
+        @DisplayName("이름, 소유자, 종류, 할인율/액수 정보가 있어야 한다.")
+        @Test
+        void shouldHaveNameTypeAndOwner() {
+            // arrange
+            String name = "Test Coupon";
+            long discountAmount = 1000L;
+
+            // act
+            CouponEntity coupon = CouponEntity.ofFixed(name, owner, discountAmount);
+
+            // assert
+            assertThat(coupon.getName()).isEqualTo(name);
+            assertThat(coupon.getOwner()).isEqualTo(owner);
+            assertThat(coupon.getDiscountAmount(BigDecimal.valueOf(10000L))).isEqualTo(BigDecimal.valueOf(discountAmount));
+        }
+
+        @DisplayName("정보가 누락되면 예외가 발생한다.")
+        @Test
+        void shouldThrowExceptionWhenMissingInfo() {
+            // arrange
+            String name = null;
+            UserEntity owner = null;
+            long discountAmount = 1000L;
+            // act & assert
+            assertThrows(IllegalArgumentException.class, () -> {
+                CouponEntity.ofFixed(name, owner, discountAmount);
+            });
+        }
+
+        @DisplayName("정액 쿠폰의 할인 금액은 0보다 커야 한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {0L, -100L, -1000L})
+        void fixedCouponDiscountAmountMustBePositive(long discountAmount) {
+            // arrange
+            String name = "Test Fixed Coupon";
+            // act & assert
+            assertThrows(IllegalArgumentException.class, () -> {
+                CouponEntity.ofFixed(name, owner, discountAmount);
+            });
+        }
+
+        @DisplayName("정률 쿠폰의 할인 비율은 0% 초과 100% 이하여야 한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {0L, 101L, -50L, 1000L})
+        void percentageCouponDiscountRateMustBeValid(long discountRate) {
+            // arrange
+            String name = "Test Percentage Coupon";
+            // act & assert
+            assertThrows(IllegalArgumentException.class, () -> {
+                CouponEntity.ofPercentage(name, owner, discountRate);
+            });
+        }
+    }
+
+    @DisplayName("쿠폰의 할인 금액을 계산할 때, ")
+    @Nested
+    class CalculateDiscountAmount {
+
+        @DisplayName("정액 쿠폰의 할인 금액이 원래 가격보다 작거나 같으면 해당 금액을 반환한다.")
+        @Test
+        void fixedCouponDiscountAmount() {
+            // arrange
+            String name = "Fixed Coupon";
+            long discountAmount = 1000L;
+            CouponEntity coupon = CouponEntity.ofFixed(name, owner, discountAmount);
+            BigDecimal originalPrice = BigDecimal.valueOf(5000L);
+
+            // act
+            BigDecimal discount = coupon.getDiscountAmount(originalPrice);
+
+            // assert
+            assertThat(discount).isEqualTo(BigDecimal.valueOf(discountAmount));
+        }
+
+        @DisplayName("정액 쿠폰의 할인 금액이 원래 가격보다 크면 원래 가격을 반환한다.")
+        @Test
+        void fixedCouponDiscountAmountExceedsOriginalPrice() {
+            // arrange
+            String name = "Fixed Coupon";
+            long discountAmount = 10000L;
+            CouponEntity coupon = CouponEntity.ofFixed(name, owner, discountAmount);
+            BigDecimal originalPrice = BigDecimal.valueOf(5000L);
+
+            // act
+            BigDecimal discount = coupon.getDiscountAmount(originalPrice);
+
+            // assert
+            assertThat(discount).isEqualTo(originalPrice);
+        }
+
+
+        @DisplayName("정률 쿠폰은 원래 가격에 할인 비율을 적용한다.")
+        @Test
+        void percentageCouponDiscountAmount() {
+            // arrange
+            String name = "Percentage Coupon";
+            long discountRate = 20L; // 20%
+            CouponEntity coupon = CouponEntity.ofPercentage(name, owner, discountRate);
+            BigDecimal originalPrice = BigDecimal.valueOf(5000L);
+
+            // act
+            BigDecimal discount = coupon.getDiscountAmount(originalPrice);
+
+            // assert
+            BigDecimal expectedDiscount = originalPrice
+                    .multiply(BigDecimal.valueOf(discountRate))
+                    .divide(BigDecimal.valueOf(100), 0, RoundingMode.HALF_UP);
+            assertThat(discount).isEqualTo(expectedDiscount);
+        }
+    }
+
+    @DisplayName("쿠폰을 사용할 때, ")
+    @Nested
+    class UseCoupon {
+
+        @DisplayName("쿠폰은 최대 한번만 사용될 수 있다.")
+        @Test
+        void couponCanBeUsedOnce() {
+            // arrange
+            String name = "Single Use Coupon";
+            long discountAmount = 500L;
+            CouponEntity coupon = CouponEntity.ofFixed(name, owner, discountAmount);
+
+            // act
+            assertThat(coupon.isUsed()).isFalse();
+            coupon.use();
+            assertThat(coupon.isUsed()).isTrue();
+
+            // assert
+            assertThrows(IllegalStateException.class, coupon::use);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
@@ -64,14 +64,14 @@ public class LikeServiceTest {
             userRepository.save(user);
             productRepository.save(product);
 
-            long countBefore = likeRepository.countAll();
+            long countBefore = likeRepository.count();
 
             // act
             likeService.addLike(user.getId(), product.getId());
             likeService.addLike(user.getId(), product.getId());
 
             // assert
-            assertThat(likeRepository.countAll()).isEqualTo(countBefore + 1);
+            assertThat(likeRepository.count()).isEqualTo(countBefore + 1);
         }
 
         @DisplayName("취소할 때, 이미 취소된 상품에 대해서는 멱등적으로 동작한다")

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderEntityTest.java
@@ -119,7 +119,7 @@ public class OrderEntityTest {
 
             // assert
             assertThat(order.getItems()).hasSize(2);
-            assertThat(order.getTotalPrice()).isEqualTo(totalPrice);
+            assertThat(order.getOriginalPrice()).isEqualTo(totalPrice);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -3,9 +3,8 @@ package com.loopers.domain.point;
 import com.loopers.application.user.UserFacade;
 import com.loopers.domain.user.UserGender;
 import com.loopers.interfaces.api.user.UserV1Dto;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -72,8 +71,7 @@ public class PointServiceIntegrationTest {
             Long nonExistentUserId = 999L;
 
             // act & assert
-            CoreException exception = assertThrows(CoreException.class, () -> pointService.findByUserId(nonExistentUserId));
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+            assertThrows(EntityNotFoundException.class, () -> pointService.findByUserId(nonExistentUserId));
         }
     }
 
@@ -88,10 +86,7 @@ public class PointServiceIntegrationTest {
             BigDecimal chargeAmount = BigDecimal.valueOf(100);
 
             // act & assert
-            CoreException exception = assertThrows(CoreException.class, () -> {
-                userFacade.charge(nonExistentUserId, chargeAmount);
-            });
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+            assertThrows(EntityNotFoundException.class, () -> userFacade.charge(nonExistentUserId, chargeAmount));
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,8 +1,7 @@
 package com.loopers.domain.user;
 
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -84,8 +83,7 @@ class UserServiceIntegrationTest {
             UserEntity saved = userService.save(newUser);
 
             // assert
-            CoreException exception = assertThrows(CoreException.class, () -> userService.save(newUser));
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+            assertThrows(IllegalArgumentException.class, () -> userService.save(newUser));
         }
     }
 
@@ -120,8 +118,7 @@ class UserServiceIntegrationTest {
             Long nonExistentId = 999L;
 
             // act & assert
-            CoreException exception = assertThrows(CoreException.class, () -> userService.findById(nonExistentId));
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+            assertThrows(EntityNotFoundException.class, () -> userService.findById(nonExistentId));
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/InMemoryCrudRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/InMemoryCrudRepository.java
@@ -17,6 +17,11 @@ public class InMemoryCrudRepository<T extends BaseEntity> implements CustomCrudR
     protected final ConcurrentMap<Long, T> map = new ConcurrentHashMap<>();
 
     @Override
+    public long count() {
+        return map.size();
+    }
+
+    @Override
     public T save(T entity) {
         if (entity == null) {
             throw new IllegalArgumentException("Entity cannot be null");

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/brand/FakeBrandRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/brand/FakeBrandRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.BrandEntity;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.infrastructure.InMemoryCrudRepository;
+
+public class FakeBrandRepository extends InMemoryCrudRepository<BrandEntity> implements BrandRepository {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/coupon/FakeCouponRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/coupon/FakeCouponRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponEntity;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.infrastructure.InMemoryCrudRepository;
+
+public class FakeCouponRepository extends InMemoryCrudRepository<CouponEntity> implements CouponRepository {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/like/FakeLikeRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/like/FakeLikeRepository.java
@@ -50,4 +50,10 @@ public class FakeLikeRepository extends InMemoryCrudRepository<LikeEntity> imple
                 .collect(Collectors.toSet());
     }
 
+    @Override
+    public LikeEntity saveOrFind(LikeEntity likeEntity) {
+        LikeEntity like = map.putIfAbsent(likeEntity.getId(), likeEntity);
+        return like != null ? like : likeEntity;
+    }
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/like/FakeLikeRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/like/FakeLikeRepository.java
@@ -1,22 +1,16 @@
 package com.loopers.infrastructure.like;
 
+import com.loopers.domain.like.LikeCountDto;
 import com.loopers.domain.like.LikeEntity;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.infrastructure.InMemoryCrudRepository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class FakeLikeRepository extends InMemoryCrudRepository<LikeEntity> implements LikeRepository {
-
-    @Override
-    public long countAll() {
-        return map.size();
-    }
 
     @Override
     public long countByProductId(Long productId) {
@@ -26,14 +20,10 @@ public class FakeLikeRepository extends InMemoryCrudRepository<LikeEntity> imple
     }
 
     @Override
-    public Map<Long, Long> countByProductIds(List<Long> productIds) {
+    public List<LikeCountDto> findLikeCountsByProductIds(List<Long> productIds) {
         return productIds.stream()
-                .collect(Collectors.toMap(
-                        productId -> productId,
-                        this::countByProductId,
-                        (existing, replacement) -> existing,
-                        ConcurrentHashMap::new
-                ));
+                .map(productId -> new LikeCountDto(productId, countByProductId(productId)))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/order/FakeOrderRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/order/FakeOrderRepository.java
@@ -2,7 +2,14 @@ package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.OrderEntity;
 import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.user.UserEntity;
 import com.loopers.infrastructure.InMemoryCrudRepository;
 
 public class FakeOrderRepository extends InMemoryCrudRepository<OrderEntity> implements OrderRepository {
+    @Override
+    public long countByUser(UserEntity user) {
+        return findAll().stream()
+                .filter(order -> order.getUser().equals(user))
+                .count();
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/point/FakePointRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/point/FakePointRepository.java
@@ -13,4 +13,11 @@ public class FakePointRepository extends InMemoryCrudRepository<PointEntity> imp
                 .filter(point -> point.getUser().getId().equals(id))
                 .findFirst();
     }
+
+    @Override
+    public Optional<PointEntity> findByUserIdWithPessimisticLock(long userId) {
+        return map.values().stream()
+                .filter(point -> point.getUser().getId().equals(userId))
+                .findFirst();
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ subprojects {
     }
 
     dependencies {
+        implementation("org.springframework.retry:spring-retry:2.0.12")
         // Web
         runtimeOnly("org.springframework.boot:spring-boot-starter-validation")
         // Spring


### PR DESCRIPTION
## 📌 Summary

4주차 과제인 동시성 제어와 쿠폰 기능을 구현했습니다.

- **주문 동시성 제어**: `주문(Order)` 생성 시 발생할 수 있는 동시성 문제를 해결하기 위해 Lock 을 도입했습니다.
  - `포인트(Point)`: 사용자의 자산과 직결되므로 데이터 정합성을 최우선으로 고려하여 비관적 락(Pessimistic Lock)을 적용했습니다.
  - `상품 재고(Product)`, `쿠폰(Coupon)`: 동시 요청 시 재시도를 통해 처리가 가능하다고 판단하여 낙관적 락(Optimistic Lock)을 적용했습니다.
- **쿠폰 기능 추가**: 주문 시 사용할 수 있는 정액/정률 쿠폰 도메인을 설계하고, 주문 로직에 적용했습니다.
- **동시성 테스트**: `Testcontainers`와 `CountDownLatch`를 활용하여 여러 사용자가 동시에 주문하는 상황을 시뮬레이션하고, 락 전략이 정상적으로 동작하여 데이터 정합성이 깨지지 않음을 검증하는 테스트 코드를 작성했습니다.

## 💬 Review Points

1.  **`Pessimistic Lock`의 범위와 트랜잭션 경계에 대한 고민**

    - **배경**: 사용자의 자산과 직결되는 `포인트(Point)` 차감 로직에는 데이터 정합성을 최우선으로 고려하여 비관적 락(`select for update`)을 적용했습니다.
    - **고민**: 제가 이해하기로 이 락은 `placeOrder`라는 **하나의 트랜잭션이 끝날 때까지 유지**됩니다. 주문 로직이 복잡해져 트랜잭션의 길이가 길어진다면, 해당 사용자의 포인트 레코드에 락이 걸리는 시간도 길어져 다른 요청(예: 다른 주문, 포인트 충전)의 성능에 영향을 줄 수 있다고 생각합니다.
    - **질문**: 현재와 같은 **모놀리식 아키텍처에서, 데이터 정합성과 성능 사이의 트레이드오프**를 고려할 때, 이처럼 긴 트랜잭션 범위를 감수하는 것이 일반적인 접근일까요? 혹은 락의 범위를 최소화하기 위해 트랜잭션을 더 작게 분리하거나 특정 로직을 비동기로 처리하는 등의 대안이 있을지 궁금합니다.

2.  **`@Retryable`과 `@Transactional`의 상호작용에 대한 고민**

    - **배경**: 재고 차감 로직에서 발생하는 낙관적 락 충돌을 해결하기 위해 `@Retryable` 어노테이션을 사용했습니다.
    - **고민**: `@Retryable`이 동작할 때, 기존 트랜잭션은 롤백되고 **새로운 트랜잭션 안에서 재시도가 시작**된다고 이해하고 있습니다. 만약 재시도 이전에 수행된 작업 중에 멱등성이 보장되지 않는 외부 API 호출 같은 작업이 있었다면, 재시도 시 문제가 발생할 수 있다고 생각합니다.
    - **질문**: `@Retryable`을 사용할 때 발생할 수 있는 **트랜잭션 전파와 부수효과(Side Effect) 문제**를 어떻게 관리해야 할까요?

3.  **동시성 테스트의 신뢰성 검증**
    - **배경**: 4주차의 핵심 학습 목표인 동시성 제어를 검증하기 위해, 가장 문제가 될 법한 **'재고 차감' 시나리오에 집중하여 동시성 테스트를 작성**했습니다. (`OrderFacadeConcurrencyTest.java`)
    - **의도**: 이 테스트는 `CountDownLatch`를 활용해 여러 스레드가 동시에 재고를 차감할 때, `version`을 이용한 낙관적 락이 정상적으로 동작하여 최종 재고가 0이 되는지를 검증하는 데 초점을 맞췄습니다.
    - **질문**: 제가 작성한 테스트 코드가 **'재고 1개인 상품에 100명이 동시에 주문하면, 오직 1개의 주문만 성공하고 재고는 0이 된다'는 시나리오를 신뢰성 있게 검증하고 있는지, 테스트 코드의 접근 방식이나 구조 자체에 대한 피드백**을 부탁드립니다.

## ✅ Checklist

#### 🗞️ Coupon 도메인

- [x] 쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [x] 쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [x] 각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

#### 🧾 주문

- [x] 주문 전체 흐름에 대해 원자성이 보장되어야 한다. (`@Transactional` 적용)
- [x] 사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [x] 재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [x] 주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다.
- [x] 쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [x] 주문 성공 시, 모든 처리는 정상 반영되어야 한다.

#### 🧪 동시성 테스트

- [x] 동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [x] 동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [x] 동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.
- [x] 동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.
